### PR TITLE
Downgrade Vert.x dependencies to 3.9.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>5.0.7</vertx.version>
+    <vertx.version>3.9.16</vertx.version>
     <junit.version>4.13.2</junit.version>
     <commons-io.version>2.21.0</commons-io.version>
   </properties>
 
   <groupId>jp.co.sony.csl.dcoes.apis</groupId>
   <artifactId>apis-bom</artifactId>
-  <version>3.4.1</version>
+  <version>3.0.0</version>
   <packaging>pom</packaging>
 
   <name>APIS BOM</name>


### PR DESCRIPTION
This PR updates the Bill of Materials to specify Vert.x 3.9.16 as the standard version across all modules.
Changes:
- Updated pom.xml to set Vert.x version to 3.9.16
This ensures all dependent modules use the same Vert.x version for consistency.
Co-authored-by: YATIN JAMWAL <YATIN072007@users.noreply.github.com>