### PR TITLE
Upgrade actions/checkout version in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,11 +55,9 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-<<<<<<< Emma-patch-improve-scorecard-sast
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-=======
+
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
->>>>>>> main
+
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`


### PR DESCRIPTION
Remove merge conflict markers from codeql.yml.
PR #21 accidentally committed unresolved merge conflict markers  into codeql.yml. This caused the OpenSSF Scorecard CI/CD workflow check to fail, dropping the score by 0.5.

 This PR removes the conflict markers and keeps the correctversion (actions/checkout@v6.0.2) which was already on main via the dependabot upgrade in #18.

@AkarshSahlot Could you please review it when you are available? thank you!