### PR TITLE
APIS-BOM depends on APIS-COMMONS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>jp.co.sony.csl.dcoes.apis</groupId>
+        <artifactId>apis-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
         <version>${vertx.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>3.9.16</vertx.version>
+    <vertx.version>3.9.14</vertx.version>
     <junit.version>4.13.2</junit.version>
     <commons-io.version>2.21.0</commons-io.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>jp.co.sony.csl.dcoes.apis</groupId>
-        <artifactId>apis-common</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
         <version>${vertx.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>5.0.7</vertx.version>
+    <vertx.version>3.9.16</vertx.version>
     <junit.version>4.13.2</junit.version>
     <commons-io.version>2.21.0</commons-io.version>
   </properties>


### PR DESCRIPTION
APIS-BOM holds external library dependencies and APIS-COMMON holds base Java library.   Need to properly resolve circular dependencies.