### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,9 @@
 
   <dependencyManagement>
     <dependencies>
-    <dependency>
+      <!-- this is not a circular dependency, this is to centralise the version management for all external
+       and internal dependencies -->
+      <dependency>
         <groupId>jp.co.sony.csl.dcoes.apis</groupId>
         <artifactId>apis-common</artifactId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
 
   <dependencyManagement>
     <dependencies>
+    <dependency>
+        <groupId>jp.co.sony.csl.dcoes.apis</groupId>
+        <artifactId>apis-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>


### PR DESCRIPTION
Keep apis-common version here as part of the BOM for dependency management. It is not being called or used here, it is just a way to manage dependencies from a single source which is this apis-bom job, so I believe we should keep it